### PR TITLE
Make browser-compatible, reduce allocations during encoding and decoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typeid-ts",
-  "version": "0.2.1",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typeid-ts",
-      "version": "0.2.1",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^11.0.0",
@@ -33,9 +33,6 @@
         "ts-api-utils": "~0.0.44",
         "ts-node": "^10.9.1",
         "typescript": "~5.0"
-      },
-      "engines": {
-        "node": ">= 18.12 <19"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
1. Replace direct usage of node.js `Buffer` API to allow the library to work in both browser and node environments

2. Improve performance by not allocating `buffer` in every `encode` call and `v` in every `decode` call - instead use one preallocated buffer for both cases. This is safe because: 
 * Both `buffer` and `v` always have length 26
 * Every element is written
 * Both are internal and are not returned to the caller, so don't need a unique reference.