### PR TITLE
Alternate, await-free import of UUIDv7 ESM module.

### DIFF
--- a/src/lib/basics.ts
+++ b/src/lib/basics.ts
@@ -1,8 +1,13 @@
 import { validatePrefix, validateSuffix } from './validators.js'
-import { uuidv7 } from 'uuidv7'
 import { ITypeID } from './models/typeid.js'
 import { uuidStringToBytes } from './encoders.js'
 import { encode } from '../base32.js'
+
+let uuidv7
+(async () => {
+  const mod = await import('uuidv7')
+  uuidv7 = mod.uuidv7
+})()
 
 export function generateNew(prefix: string): string {
     return from(prefix, '')


### PR DESCRIPTION
(Apologies for all the recent commits about this - these all should have been one commit if I had been properly paying attention.)

This PR changes to an alternate import of UUIDv7, where the module is imported using the CommonJS-safe `await import(module)` method inside of an anonymous function, which is then executed immediately.  By the time the `uuidv7()` function is called later, it is nearly guaranteed to be loaded (like 5-9's guarantee, similar reliability to "UUIDs will not collide").

Without this, importing the module as CommonJS will _work,_ but the moment `basics.ts` is imported, the compiler with throw an error similar to `Error [ERR_REQUIRE_ESM]: require() of ES Module PROJECT/node_modules/uuidv7/dist/index.js from PROJECT/node_modules/typeid-ts/build/cjs/src/lib/basics.js not supported.`, as UUIDv7 does not expose a CommonJS export.

The only other ways of accomplishing this is to add the `await import` statement inside the `from()` function, which would change its signature to an async function, which reduces usability for ESM importers, or to custom-recompile UUIDv7 into a CommonJS-compatible format in the build step, as the maintainer of that library has indicated that they will not ever be adding a CommonJS export.