### PR TITLE
Fix build-esm and build-cjs not replacing existing build directory.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "prebuild": "npm run lint",
     "prepublishOnly": "tsc -p tsconfig.json",
     "build": "npm run build-esm && npm run build-cjs",
-    "build-esm": "tsc -p tsconfig.json --module es2022 --outDir build/esm/ && echo '{\"type\": \"module\"}' > build/esm/package.json",
-    "build-cjs": "tsc -p tsconfig.json --module commonjs --outDir build/cjs/ && shx echo '{\"type\": \"commonjs\"}' > build/cjs/package.json",
+    "build-esm": "rm -rf build/esm && tsc -p tsconfig.json --module es2022 --outDir build/esm/ && echo '{\"type\": \"module\"}' > build/esm/package.json",
+    "build-cjs": "rm -rf build/cjs && tsc -p tsconfig.json --module commonjs --outDir build/cjs/ && shx echo '{\"type\": \"commonjs\"}' > build/cjs/package.json",
     "build:watch": "tsc -w -p tsconfig.json",
     "lint": "eslint . --ext .ts --ext .mts",
     "test": "mocha -r ts-node/register ./test/**/*.ts"


### PR DESCRIPTION
I figured out why the published 0.3.0 didn't have an updated build directory - if you don't remove the build folders before running build, sometimes it chooses to believe that the build folder is a safe cache and it won't update the files there.  To fix this, we should remove the fils from the build folder before running build, ensuring that all files are freshly built every time.